### PR TITLE
  Fix the problem that the socket was not opened before it was used

### DIFF
--- a/PacketConnection/Sender.cpp
+++ b/PacketConnection/Sender.cpp
@@ -5,10 +5,17 @@ namespace Gaia::Connections::PacketConnection
 	/// Acquire the socket for sending packet.
 	boost::asio::ip::udp::socket& Sender::GetSocket()
 	{
-		// Use inner static variable to prevent exception from escaping during its construction.
-		static boost::asio::io_context context_instance {};
-		static boost::asio::ip::udp::socket socket_instance {context_instance};
-		return socket_instance;
+        static std::unique_ptr<boost::asio::io_context> context_instance;
+        static std::unique_ptr<boost::asio::ip::udp::socket> socket_instance;
+
+        if (!socket_instance)
+        {
+            context_instance = std::make_unique<boost::asio::io_context>();
+            socket_instance = std::make_unique<boost::asio::ip::udp::socket>(*context_instance);
+            socket_instance->open(boost::asio::ip::udp::v4());
+        }
+
+        return *socket_instance;
 	}
 
     /// Static function for sending packet that has been constructed.
@@ -16,7 +23,6 @@ namespace Gaia::Connections::PacketConnection
     {
         // Send the data of packet to the packet's destination
         GetSocket().send_to(boost::asio::buffer(packet.Data), packet.Address);
-
     }
 
     /// Static function in order to sending packet only for temporariness without constructing Packet.
@@ -24,6 +30,5 @@ namespace Gaia::Connections::PacketConnection
     {
         // Send the data to the destination described in the parameter
         GetSocket().send_to(boost::asio::buffer(data), address);
-
     }
 }


### PR DESCRIPTION
In the GetSocket() function,  an open operation for socket is added to fix the problem of socket calling send_to(...) function will throw an exception.
