### PR TITLE
Finish the tcp module of the GaiaConnections

### DIFF
--- a/ChannelConneciton/CMakeLists.txt
+++ b/ChannelConneciton/CMakeLists.txt
@@ -1,0 +1,56 @@
+#==============================
+# Requirements
+#==============================
+
+cmake_minimum_required(VERSION 3.10)
+
+#==============================
+# Unit Settings
+#==============================
+
+set(TARGET_NAME "PacketConnection")
+
+#==============================
+# Command Lines
+#==============================
+
+set(CMAKE_CXX_STANDARD 17)
+
+#==============================
+# Source
+#==============================
+
+#------------------------------
+# C++
+#------------------------------
+# C++ Source Files
+file(GLOB_RECURSE TARGET_SOURCE "*.cpp")
+# C++ Header Files
+file(GLOB_RECURSE TARGET_HEADER "*.hpp")
+
+#==============================
+# Compile Targets
+#==============================
+
+# To lower the running cost, this module will be compiled as a static library.
+add_library(${TARGET_NAME} STATIC ${TARGET_SOURCE} ${TARGET_HEADER} ${TARGET_CUDA_SOURCE} ${TARGET_CUDA_HEADER})
+
+# Enable 'DEBUG' Macro in Debug Mode
+if(CMAKE_BUILD_TYPE STREQUAL Debug)
+    target_compile_definitions(${TARGET_NAME} PRIVATE  -DDEBUG)
+endif()
+
+#==============================
+# Dependencies
+#==============================
+
+# Boost
+find_package(Boost 1.71 REQUIRED COMPONENTS system)
+target_include_directories(${TARGET_NAME} PUBLIC ${Boost_INCLUDE_DIRS})
+target_link_libraries(${TARGET_NAME} PUBLIC ${Boost_LIBRARIES})
+
+# In Linux, 'Threads' need to explicitly linked.
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+    find_package(Threads)
+    target_link_libraries(${TARGET_NAME} PUBLIC ${CMAKE_THREAD_LIBS_INIT})
+endif()

--- a/ChannelConneciton/Channel.cpp
+++ b/ChannelConneciton/Channel.cpp
@@ -1,0 +1,121 @@
+#include "Channel.hpp"
+
+
+namespace Gaia::Connections::ChannelConnection{
+    Channel::Channel(): Socket(Context)
+    {
+
+    }
+    Channel::Channel(const EndPoint& endPoint): Socket(Context)
+    {
+
+        Socket.connect(endPoint, error_code);
+
+        if(!error_code)
+        {
+            Connected = true;
+        }
+        else
+        {
+            throw boost::system::system_error(error_code);
+        }
+    }
+
+    Channel::Channel(int port):Socket(Context), RemoteEndpoint(boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), port))
+    {
+
+    }
+
+    void Channel::Bind(int port)
+    {
+        RemoteEndpoint = boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), port);
+    }
+
+    void Channel::Bind(boost::asio::ip::tcp::endpoint endpoint_)
+    {
+        RemoteEndpoint = std::move(endpoint_);
+
+    }
+
+    void Channel::DisConnected() {
+
+        Socket.close(error_code);
+
+        if(!error_code)
+        {
+            Connected = false;
+        }
+        else
+        {
+            throw boost::system::system_error(error_code);
+        }
+    }
+
+    bool Channel::IsConnected() const
+    {
+        return Connected;
+    }
+
+    void Channel::Connect(const Channel::EndPoint& endPoint)
+    {
+        Socket.connect(endPoint,error_code);
+        if(error_code)
+        {
+            throw boost::system::system_error(error_code);
+        }
+
+    }
+
+    void Channel::Listen()
+    {
+        boost::asio::ip::tcp::acceptor acceptor_(Context, RemoteEndpoint);
+        acceptor_.accept(Socket,error_code);
+        if(error_code)
+        {
+            throw boost::system::system_error(error_code);
+        }
+    }
+
+    std::vector<unsigned char> Channel::Read()
+    {
+        std::vector<unsigned char> data(MaxDataSize);
+        std::size_t received_size = 0;
+
+        while (received_size < MaxDataSize) {
+
+            received_size += Socket.read_some(boost::asio::buffer(data), error_code);
+            if (error_code) {
+                throw boost::system::system_error(error_code);
+            }
+        }
+        return data;
+    }
+
+    void Channel::SetDataMaxSize(size_t max_data_size)
+    {
+        MaxDataSize = max_data_size;
+
+    }
+
+    std::vector<unsigned char> Channel::Read(size_t length) {
+        std::vector<unsigned char> data(length);
+        std::size_t received_size = 0;
+
+        while (received_size < length) {
+
+            received_size += Socket.read_some(boost::asio::buffer(data), error_code);
+            if (error_code) {
+                throw boost::system::system_error(error_code);
+            }
+        }
+
+        return data;
+    }
+
+    void Channel::Write(std::vector<unsigned char> data) {
+        Socket.write_some(boost::asio::buffer(data), error_code);
+        if (error_code) {
+            throw boost::system::system_error(error_code);
+        }
+    }
+};

--- a/ChannelConneciton/Channel.hpp
+++ b/ChannelConneciton/Channel.hpp
@@ -1,0 +1,80 @@
+#pragma once
+#include <boost/asio.hpp>
+namespace Gaia::Connections::ChannelConnection
+{
+    /**
+     * @brief Create a Channel for the TCP connection.
+     */
+    class Channel
+    {
+    private:
+        // IO context for following IO operations.
+        boost::asio::io_context Context{};
+        // Socket for creating the Channel.
+        boost::asio::ip::tcp::socket Socket;
+        // The remote endpoint that will be connected.
+        boost::asio::ip::tcp::endpoint RemoteEndpoint;
+        // The size of Channel`s IO buffer. The default size is 512.
+        size_t MaxDataSize = {512};
+        //Whether the Channel is established already.
+        bool Connected = false;
+
+        boost::system::error_code error_code;
+    public:
+        using EndPoint = boost::asio::ip::tcp::endpoint;
+        //Default Constructor, which only initialize the Socket.
+        Channel();
+
+        // Construct with port and remote endpoint.
+        // Local Socket will try to connect with the remote endpoint if this constructor is called.
+        explicit Channel(const EndPoint& endPoint);
+
+        // Construct with specified port.
+        // The Socket will be bound with the specified port if this constructor is called.
+        explicit Channel(int port);
+
+        ///Bind The Socket with specified port.
+        void Bind(int port);
+        ///Bind The Socket with specified port.
+        void Bind(boost::asio::ip::tcp::endpoint point_);
+
+        ///Close the established Channel.
+        void DisConnected();
+
+        bool IsConnected() const;
+
+        void SetDataMaxSize(size_t max_data_size);
+
+        /**
+         * @brief Try to connect with the specified endpoint.
+         * @pre The Socket was bound with port and the specified remote endpoint must call the Accept() first.
+         */
+        void Connect(const EndPoint& endPoint);
+
+        /**
+         * @brief Wait for another Socket to Connect
+         * @pre Local Socket was bound with specified port first.
+         */
+        void Listen();
+
+        /**
+         * @brief Read the data in the Channel`s buffer till the data size meet the MaxDataSize.
+         * @pre The Channel was Established already.
+         * @return Vector of the transmitted data.
+         */
+        std::vector<unsigned char> Read();
+        /**
+         * @brief Read a specific amount of data from Channel`s buffer.
+         * @pre The Channel was Established already.
+         * @param length: The specified length of data which is ready to be read
+         * @return Vector of the transmitted data of specified length.
+         */
+        std::vector<unsigned char> Read(size_t length);
+        /**
+         * @brief Write some data into the Channel`s buffer.
+         * @pre The Channel was Established already.
+         */
+        void Write(std::vector<unsigned char> data);
+
+    };
+}

--- a/ChannelConneciton/Channel.hpp
+++ b/ChannelConneciton/Channel.hpp
@@ -1,9 +1,20 @@
 #pragma once
+
 #include <boost/asio.hpp>
+
 namespace Gaia::Connections::ChannelConnection
 {
     /**
      * @brief Create a Channel for the TCP connection.
+     * @details The Channel could be used as a server or a client. As the server, the Socket must be bound with a specified port and
+     * IP. The localhost will be bound to the Socket if there is not a specified IP. Then call the function Listen(), the Socket
+     * starts wait for the connecting. After connecting successfully, the users could use function Write() or Read() to send or get
+     * data from TCP IO stream.
+     * As the client, the users can construct the Channel with specified remote endpoint so that the Socket will try to connect to
+     * the remote endpoint directly. Another way to connect is the function Connect().Before calling the Connect(), the remote
+     * endpoint must be specified.
+     * @attention The Channel will throw a exception out the error if here are some errors occur.
+     *
      */
     class Channel
     {
@@ -16,7 +27,7 @@ namespace Gaia::Connections::ChannelConnection
         boost::asio::ip::tcp::endpoint RemoteEndpoint;
         // The size of Channel`s IO buffer. The default size is 512.
         size_t MaxDataSize = {512};
-        //Whether the Channel is established already.
+        // Whether the Channel is established already.
         bool Connected = false;
 
         boost::system::error_code error_code;

--- a/PacketConnection/CMakeLists.txt
+++ b/PacketConnection/CMakeLists.txt
@@ -33,7 +33,7 @@ file(GLOB_RECURSE TARGET_HEADER "*.hpp")
 #==============================
 
 # To lower the running cost, this module will be compiled as a static library.
-add_library(${TARGET_NAME} STATIC ${TARGET_SOURCE} ${TARGET_HEADER} ${TARGET_CUDA_SOURCE} ${TARGET_CUDA_HEADER})
+add_library(${TARGET_NAME} STATIC ${TARGET_SOURCE} ${TARGET_HEADER} ${TARGET_CUDA_SOURCE} ${TARGET_CUDA_HEADER} ../ChannelConneciton/Channel.cpp ../ChannelConneciton/Channel.hpp)
 
 # Enable 'DEBUG' Macro in Debug Mode
 if(CMAKE_BUILD_TYPE STREQUAL Debug)

--- a/PacketConnection/Receiver.hpp
+++ b/PacketConnection/Receiver.hpp
@@ -41,7 +41,7 @@ namespace Gaia::Connections::PacketConnection
          *  Sometimes IP is necessary when there are multiple network cards on the computer,
          *  and users want to bind Receiver on one of them.
          */
-        explicit Receiver(const boost::asio::ip::udp::endpoint& address);
+        Receiver(const boost::asio::ip::udp::endpoint& address);
         /**
          * @brief Construct and bind to a port on local host.
          * @param port Port to bind.


### PR DESCRIPTION
The Channel could be used to start a connection between two endpoints and read or write data to to the data buffer.